### PR TITLE
Adapt to new arguments for docs publishing

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -211,7 +211,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4.4.0
         if: startsWith(github.event.ref, 'refs/tags')
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: doc/build/html
           CLEAN: true


### PR DESCRIPTION
As title says - Action does not accept GITHUB_TOKEN, but TOKEN