### PR TITLE
Update bomanalytics URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ At this moment, this package ensures the compatibility between the following PyA
 - `PyPrimeMesh <https://prime.docs.pyansys.com>`_: Pythonic interface to Ansys Prime Server which delivers core Ansys meshing technology.
 - `PySeascape <https://seascape.docs.pyansys.com/>`_: Pythonic interface to communicate with RedHawkSC and TotemSC.
 - `PyTwin <https://twin.docs.pyansys.com/>`_: Pythonic interface to communicate with Ansys Digital Twins consumption workflows.
-- `Granta MI BoM Analytics <https://grantami.docs.pyansys.com/>`_: Pythonic interface to Granta MI BoM Analytics services.
+- `Granta MI BoM Analytics <https://bomanalytics.grantami.docs.pyansys.com/>`_: Pythonic interface to Granta MI BoM Analytics services.
 - `Shared Components <https://shared.docs.pyansys.com/>`_: Shared software components to enable package interoperability and minimize maintenance.
 
 Much effort is underway to continue expanding and developing packages in the

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -100,7 +100,7 @@ PyAnsys packages API reference
 
     .. grid-item-card:: Granta MI BoM Analytics
       :img-top: _static/thumbnails/intro.png
-      :link: https://grantami.docs.pyansys.com/api/index.html
+      :link: https://bomanalytics.grantami.docs.pyansys.com/version/stable/index.html
       :text-align: center
       :class-title: pyansys-card-title
 

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -89,7 +89,7 @@ PyAnsys packages examples
 
     .. grid-item-card:: Granta MI BoM Analytics
       :img-top: _static/thumbnails/intro.png
-      :link: https://grantami.docs.pyansys.com/examples/index.html
+      :link: https://bomanalytics.grantami.docs.pyansys.com/version/stable/examples/index.html
       :text-align: center
       :class-title: pyansys-card-title
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -122,7 +122,7 @@ it is now a collection of many Python packages for using Ansys products through 
 
     .. grid-item-card:: Granta MI BoM Analytics
       :img-top: _static/thumbnails/intro.png
-      :link: https://grantami.docs.pyansys.com/
+      :link: https://bomanalytics.grantami.docs.pyansys.com/
       :text-align: center
       :class-title: pyansys-card-title
 

--- a/doc/source/user_guide.rst
+++ b/doc/source/user_guide.rst
@@ -92,7 +92,7 @@ PyAnsys packages user guides
 
     .. grid-item-card:: Granta MI BoM Analytics
       :img-top: _static/thumbnails/intro.png
-      :link: https://grantami.docs.pyansys.com/getting_started/index.html
+      :link: https://bomanalytics.grantami.docs.pyansys.com/version/stable/getting_started/index.html
       :text-align: center
       :class-title: pyansys-card-title
 


### PR DESCRIPTION
BoM Analytics docs have been migrated from https://grantami.docs.pyansys.com/ to https://bomanalytics.grantami.docs.pyansys.com/. This PR updates links in the PyAnsys docs to the new URL.

Currently both links are valid but we plan to serve higher level documentation for all Granta MI PyAnsys packages at https://grantami.docs.pyansys.com/.